### PR TITLE
Update Readme with new property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can check [index.js](https://github.com/xgfe/react-native-datepicker/blob/ma
 | confirmBtnText | '确定' | `string` | Specify the text of confirm btn in ios. |
 | cancelBtnText | '取消' | `string` | Specify the text of cancel btn in ios. |
 | iconSource | - | <code>{uri: string} &#124; number</code> | Specify the icon. Same as the `source` of Image, always using `require()` |
+| minuteInterval | - | `enum` | The interval at which minutes can be selected. Possible values are 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30 |
 | minDate | - | <code>string &#124; date</code> | Restricts the range of possible date values. |
 | maxDate | - | <code>string &#124; date</code> | Restricts the range of possible date values. |
 | duration | 300 | `number` | Specify the animation duration of datepicker.|

--- a/__tests__/Datepicker.test.js
+++ b/__tests__/Datepicker.test.js
@@ -243,6 +243,45 @@ describe('DatePicker', () => {
     expect(onDateChange).toHaveBeenCalledTimes(1);
   });
 
+  it('onTimePicked15MinuteInterval', () => {
+    const onDateChange = jest.fn();
+    const wrapper = shallow(<DatePicker onDateChange={onDateChange} minuteInterval={15}/>);
+    const datePicker = wrapper.instance();
+
+    datePicker.onTimePicked({action: DatePickerAndroid.dismissedAction, hour: 12, minute: 10});
+    datePicker.onTimePicked({action: '', hour: 12, minute: 10});
+
+    expect(wrapper.state('date').getHours()).toEqual(12);
+    expect(wrapper.state('date').getMinutes()).toEqual(15);
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('onTimePicked30MinuteInterval', () => {
+    const onDateChange = jest.fn();
+    const wrapper = shallow(<DatePicker onDateChange={onDateChange} minuteInterval={30}/>);
+    const datePicker = wrapper.instance();
+
+    datePicker.onTimePicked({action: DatePickerAndroid.dismissedAction, hour: 12, minute: 10});
+    datePicker.onTimePicked({action: '', hour: 12, minute: 10});
+
+    expect(wrapper.state('date').getHours()).toEqual(12);
+    expect(wrapper.state('date').getMinutes()).toEqual(0);
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('onTimePicked2MinuteInterval', () => {
+    const onDateChange = jest.fn();
+    const wrapper = shallow(<DatePicker onDateChange={onDateChange} minuteInterval={2}/>);
+    const datePicker = wrapper.instance();
+
+    datePicker.onTimePicked({action: DatePickerAndroid.dismissedAction, hour: 12, minute: 9});
+    datePicker.onTimePicked({action: '', hour: 12, minute: 9});
+
+    expect(wrapper.state('date').getHours()).toEqual(12);
+    expect(wrapper.state('date').getMinutes()).toEqual(10);
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+  });
+
   it('onDatetimeTimePicked', () => {
     const onDateChange = jest.fn();
     const wrapper = shallow(<DatePicker onDateChange={onDateChange}/>);

--- a/__tests__/Datepicker.test.js
+++ b/__tests__/Datepicker.test.js
@@ -282,6 +282,19 @@ describe('DatePicker', () => {
     expect(onDateChange).toHaveBeenCalledTimes(1);
   });
 
+  it('onTimePicked15MinuteIntervalAcrossHour', () => {
+    const onDateChange = jest.fn();
+    const wrapper = shallow(<DatePicker onDateChange={onDateChange} minuteInterval={15}/>);
+    const datePicker = wrapper.instance();
+
+    datePicker.onTimePicked({action: DatePickerAndroid.dismissedAction, hour: 12, minute: 9});
+    datePicker.onTimePicked({action: '', hour: 12, minute: 58});
+
+    expect(wrapper.state('date').getHours()).toEqual(13);
+    expect(wrapper.state('date').getMinutes()).toEqual(0);
+    expect(onDateChange).toHaveBeenCalledTimes(1);
+  });
+
   it('onDatetimeTimePicked', () => {
     const onDateChange = jest.fn();
     const wrapper = shallow(<DatePicker onDateChange={onDateChange}/>);

--- a/datepicker.js
+++ b/datepicker.js
@@ -468,11 +468,11 @@ DatePicker.defaultProps = {
 };
 
 DatePicker.propTypes = {
-  mode: PropTypes.oneOf(['date', 'datetime', 'time']), 
+  mode: PropTypes.oneOf(['date', 'datetime', 'time']),
   androidMode: PropTypes.oneOf(['calendar', 'spinner', 'default']),
   date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date), PropTypes.object]),
-  format: PropTypes.string, 
-  minuteInterval: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]), 
+  format: PropTypes.string,
+  minuteInterval: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]),
   minDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   maxDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   height: PropTypes.number,

--- a/datepicker.js
+++ b/datepicker.js
@@ -157,7 +157,6 @@ class DatePicker extends Component {
 
   getDateStr(date = this.props.date) {
     const {mode, format = FORMATS[mode]} = this.props;
-
     if (date instanceof Date) {
       return Moment(date).format(format);
     } else {
@@ -206,6 +205,25 @@ class DatePicker extends Component {
 
   onTimePicked({action, hour, minute}) {
     if (action !== DatePickerAndroid.dismissedAction) {
+      const minuteInterval = this.props.minuteInterval;
+      if (minuteInterval !== undefined) {
+        const intCount = 60/minuteInterval;
+        const minIntFloor = Math.floor(minute/minuteInterval);
+        const minIntCeil = minIntFloor + 1;
+        const minFloorDiff = minute - (minIntFloor * minuteInterval);
+        const minCeilDiff = (minIntCeil * minuteInterval) - minute;
+        if (minCeilDiff <= minFloorDiff) {
+          // special case: if minIntCeil === intCount, need to advance the hour, too.
+          if (minIntCeil === intCount) {
+            hour = hour + 1;
+            minute = 0;
+          } else {
+            minute = (minIntCeil*minuteInterval);
+          }
+        } else {
+          minute = (minIntFloor * minuteInterval);
+        }
+      }
       this.setState({
         date: Moment().hour(hour).minute(minute).toDate()
       });
@@ -450,10 +468,11 @@ DatePicker.defaultProps = {
 };
 
 DatePicker.propTypes = {
-  mode: PropTypes.oneOf(['date', 'datetime', 'time']),
+  mode: PropTypes.oneOf(['date', 'datetime', 'time']), 
   androidMode: PropTypes.oneOf(['calendar', 'spinner', 'default']),
   date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date), PropTypes.object]),
-  format: PropTypes.string,
+  format: PropTypes.string, 
+  minuteInterval: PropTypes.oneOf([1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]), 
   minDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   maxDate: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   height: PropTypes.number,

--- a/datepicker.js
+++ b/datepicker.js
@@ -207,8 +207,8 @@ class DatePicker extends Component {
     if (action !== DatePickerAndroid.dismissedAction) {
       const minuteInterval = this.props.minuteInterval;
       if (minuteInterval !== undefined) {
-        const intCount = 60/minuteInterval;
-        const minIntFloor = Math.floor(minute/minuteInterval);
+        const intCount = 60 / minuteInterval;
+        const minIntFloor = Math.floor(minute / minuteInterval);
         const minIntCeil = minIntFloor + 1;
         const minFloorDiff = minute - (minIntFloor * minuteInterval);
         const minCeilDiff = (minIntCeil * minuteInterval) - minute;
@@ -218,7 +218,7 @@ class DatePicker extends Component {
             hour = hour + 1;
             minute = 0;
           } else {
-            minute = (minIntCeil*minuteInterval);
+            minute = (minIntCeil * minuteInterval);
           }
         } else {
           minute = (minIntFloor * minuteInterval);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^3.19.0",
     "eslint-plugin-react": "^7.0.1",
     "inquirer": "^3.0.5",
-    "jest": "21.2.1",
+    "jest": "^21.2.1",
     "jsdom": "^11.3.0",
     "jsdom-global": "^3.0.2",
     "pre-commit": "^1.1.3",


### PR DESCRIPTION
Adding in minuteInterval property, as it is currently supported in IOS (and the react-native-datepicker) and will soon work with the android timepicker.